### PR TITLE
Fix failing All PII Code Check

### DIFF
--- a/reports/classification/all_pii.sql
+++ b/reports/classification/all_pii.sql
@@ -9,4 +9,4 @@ SELECT
 FROM 
     sdf.information_schema.columns
 WHERE
-    cardinality(filter(classifiers, element -> contains(element, 'PII.'))) > 0;
+    CONTAINS_ARRAY_VARCHAR(classifiers, 'PII.');


### PR DESCRIPTION
We do not support lambda functions yet in filter expressions. Therefore, @wizardxz implemented a `CONTAINS_ARRAY_VARCHAR` for this operation and others.