### PR TITLE
Use length(array) instead of length_array.

### DIFF
--- a/reports/global_optimization/dead_columns.sql
+++ b/reports/global_optimization/dead_columns.sql
@@ -8,8 +8,8 @@ WITH tables_with_lineage AS (
       tl.table_id
    FROM  
       sdf.information_schema.tables tl
-   WHERE LENGTH_ARRAY(tl.depends_on) != 0 
-   AND LENGTH_ARRAY(tl.depended_on_by) != 0
+   WHERE LENGTH(tl.depends_on) != 0 
+   AND LENGTH(tl.depended_on_by) != 0
    AND (tl.purpose != 'system' AND tl.purpose != 'external-system')
 )
 

--- a/reports/structure/island_tables.sql
+++ b/reports/structure/island_tables.sql
@@ -4,6 +4,6 @@
 
 SELECT table_id
 FROM sdf.information_schema.tables
-WHERE LENGTH_ARRAY(tables.depends_on) = 0
-AND LENGTH_ARRAY(tables.depended_on_by) = 0
+WHERE LENGTH(tables.depends_on) = 0
+AND LENGTH(tables.depended_on_by) = 0
 AND purpose != 'system' AND purpose != 'external-system';

--- a/reports/structure/middle_tables.sql
+++ b/reports/structure/middle_tables.sql
@@ -5,5 +5,5 @@
 
 SELECT table_id
 FROM sdf.information_schema.tables
-WHERE LENGTH_ARRAY(tables.depends_on) != 0
-AND LENGTH_ARRAY(tables.depended_on_by) != 0;
+WHERE LENGTH(tables.depends_on) != 0
+AND LENGTH(tables.depended_on_by) != 0;

--- a/reports/structure/most_immediate_col_deps.sql
+++ b/reports/structure/most_immediate_col_deps.sql
@@ -2,6 +2,6 @@
 -- Reports all columns with the most direct downstream dependencies
 -- in descending order
 
-SELECT column_id, LENGTH_ARRAY(depended_on_by) AS downstream_dep_count
+SELECT column_id, LENGTH(depended_on_by) AS downstream_dep_count
 FROM sdf.information_schema.columns
 ORDER BY downstream_dep_count DESC;

--- a/reports/structure/most_immeditate_table_deps.sql
+++ b/reports/structure/most_immeditate_table_deps.sql
@@ -2,6 +2,6 @@
 -- Reports all columns with the most direct downstream dependencies
 -- in descending order
 
-SELECT table_id, LENGTH_ARRAY(depended_on_by) AS downstream_dep_count
+SELECT table_id, LENGTH(depended_on_by) AS downstream_dep_count
 FROM sdf.information_schema.tables
 ORDER BY downstream_dep_count DESC;


### PR DESCRIPTION
Now that we have connected to the proper UDF in datafusion, we no longer need the stop-gap substitute.