### PR TITLE
Update workspace evaluator README

### DIFF
--- a/readme.mdx
+++ b/readme.mdx
@@ -21,7 +21,7 @@ To install the workspace evaluator in your project, add the *workspace-evaluator
 workspace:
   ...
   dependencies:
-    - name: evaluator
+    - name: workspace_evaluator
       git: https://github.com/sdf-labs/workspace-evaluator/workspace-evaluator.git
 ```
 


### PR DESCRIPTION
the readme code snippet in the workspace evaluator README was incorrect, it should be `workspace_evaluator` instead of just `evaluator`. This fixes that issue